### PR TITLE
Add 0.4.0 release to index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -2,3 +2,4 @@
   0.1.0: https://github.com/SAP/java-memory-assistant/releases/download/0.1.0/java-memory-assistant-0.1.0.jar
   0.2.0: https://github.com/SAP/java-memory-assistant/releases/download/0.2.0/java-memory-assistant-0.2.0.jar
   0.3.0: https://github.com/SAP/java-memory-assistant/releases/download/0.3.0/java-memory-assistant-0.3.0.jar
+  0.4.0: https://github.com/SAP/java-memory-assistant/releases/download/0.4.0/java-memory-assistant-0.4.0.jar


### PR DESCRIPTION
Makes the 0.4.0 release usable for the [Cloud Foundry Java buildpack](https://github.com/cloudfoundry/java-buildpack/blob/master/lib/java_buildpack/framework/java_memory_assistant/agent.rb) (the `index.yml` file is used to regulate component versioning).

**IMPORTANT:** _Do not merge until the JAR file for JMA v0.4.0 is added to the [0.4.0 release](https://github.com/SAP/java-memory-assistant/releases/tag/0.4.0), or the java buildpack may break._