### PR TITLE
Allow existing license headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,12 @@ For building behind a proxy, consider setting the proxy-variables as follows:
  ```
 where, for example `[proxy_hostname]` is `proxy.wdf.sap.corp` and `[proxy_port]` is `8080`.
 
+When adding new code files to the project the build might fail with `Missing header in: [...]`. Run the following command to add a license header to all new files:
+
+```
+./gradlew LicenseFormat
+```
+
 ## Running the Java Memory Assistant on Java 11
 
 Due to the restrictions introduced by the Java module system with Java 9, the following additional argument must be passed to the `java` command:

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
             gradle = 'SLASHSTAR_STYLE'
         }
         ext.year = Calendar.getInstance().get(Calendar.YEAR)
+        skipExistingHeaders true
     }
 
     group = 'com.sap.jma'

--- a/quality/licensing/HEADER
+++ b/quality/licensing/HEADER
@@ -1,3 +1,3 @@
-Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
+Copyright (c) ${year} SAP SE or an SAP affiliate company. All rights reserved.
 This file is licensed under the Apache Software License, v. 2 except as noted
 otherwise in the LICENSE file at the root of the repository.


### PR DESCRIPTION
This change allows using the current year for new license headers while accepting existing headers without build failures.

Fixes #22 